### PR TITLE
Fix liba52 build on aarch64

### DIFF
--- a/codecs/liba52.json
+++ b/codecs/liba52.json
@@ -22,6 +22,10 @@
         {
             "type": "patch",
             "path": "liba52-prefer-pic.patch"
+        },
+        {
+            "type": "shell",
+            "commands": [ "cp -p /usr/share/automake-*/config.{sub,guess} ." ]
         }
     ]
 }


### PR DESCRIPTION
The autotools are far too old to work on a platform that didn't exist at
the time, update config.{sub,guess}.

configure: error: cannot guess build type; you must specify one