### PR TITLE
Update to 3.31.90

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -291,13 +291,12 @@
         {
             "name": "totem",
             "buildsystem": "meson",
-            "no-parallel-make": true,
             "sources": [
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/totem.git",
-                    "commit": "e99784ba94426703dfeb8333e165adca4a9551fa",
-                    "tag": "V_3_30_0"
+                    "commit": "1c732cac0cfa07cf365779d6a37b3986aafeb28b",
+                    "tag": "V_3_31_90"
                 }
             ]
         }


### PR DESCRIPTION
Vala support was removed, so no need to disable parallel make anymore.