### PR TITLE
Disable missing-plugins support

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -291,6 +291,7 @@
         {
             "name": "totem",
             "buildsystem": "meson",
+            "config-opts": ["-Denable-easy-codec-installation=no"],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
It does nothing in a sandbox. Note that it was enabled before because it
didn't compile without it before 3.31.90.