### PR TITLE
Really require aom gst-plugins-bad plugin

### DIFF
--- a/codecs/gst-plugins-bad.json
+++ b/codecs/gst-plugins-bad.json
@@ -1,7 +1,6 @@
 {
     "name": "gst-plugins-bad",
     "buildsystem": "meson",
-    "config-opts": [ "-Daom=enabled" ],
     "cleanup": [ "/bin/*webrtc*", "/bin/crossfade", "/bin/tsparser", "/bin/playout" ],
     "sources": [
         {
@@ -13,6 +12,10 @@
         {
             "type": "patch",
             "path": "gst-plugins-bad-issue-871-workaround.patch"
+        },
+        {
+            "type": "shell",
+            "commands": [ "sed s,false,true, -i ext/aom/meson.build" ]
         }
     ],
     "post-install": [

--- a/codecs/libaom.json
+++ b/codecs/libaom.json
@@ -1,0 +1,14 @@
+{
+    "name": "aom",
+    "buildsystem": "cmake-ninja",
+    "builddir" : true,
+    "config-opts" : [ "-DBUILD_SHARED_LIBS=YES", "-DENABLE_DOCS=NO", "-DENABLE_NASM=YES", "-DENABLE_NEON=NO" ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://aomedia.googlesource.com/aom",
+            "commit": "add4b15580e410c00c927ee366fa65545045a5d9",
+            "tag" : "v1.0.0-errata1"
+        }
+    ]
+}

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -61,6 +61,7 @@
     "cleanup": [ "/include", "/share/bash-completion", "/lib/gstreamer-1.0/" ],
     "modules": [
         "shared-modules/lua5.3/lua-5.3.2.json",
+        "codecs/libaom.json",
         "codecs/gst-libav.json",
         "codecs/liba52.json",
         "codecs/gst-plugins-ugly.json",
@@ -307,6 +308,7 @@
         }
     ],
     "cleanup-commands" : [
+        "mv /app/lib/libaom*.so* /app/lib/codecs/lib/",
         "mv /app/lib/libdvd*.* /app/lib/liba52*.* /app/lib/codecs/lib/",
         "mv /app/lib/libass.* /app/lib/codecs/lib/"
     ]


### PR DESCRIPTION
We use meson to build gst-plugins-bad 1.14.4, and pass it an option
to force the aom plugin to be built, but this option was only added in
1.15.1.

Modify the meson.build for the plugin so that it's required until we
upgrade to 1.16.