### PR TITLE
Allow access to gvfs' FUSE mount

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -34,6 +34,7 @@
         "--filesystem=/run/media",
         /* Browse gvfs */
         "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*",
+        "--filesystem=xdg-run/gvfs",
         /* Needed for dconf to work */
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",


### PR DESCRIPTION
So that in addition to browsing remote mounts we can also access the
POSIX style files. This fixes fetching subtitles with the OpenSubtitles
plugins for remote files.