### PR TITLE
Move DLNA support inside the sandbox

### DIFF
--- a/dleyna/dleyna-connector-dbus.json
+++ b/dleyna/dleyna-connector-dbus.json
@@ -1,0 +1,10 @@
+{
+    "name": "dleyna-connector-dbus",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/intel/dleyna-connector-dbus.git",
+            "commit": "1f0932aaacdd67700912a0c9c6e610f16f346ced"
+        }
+    ]
+}

--- a/dleyna/dleyna-core.json
+++ b/dleyna/dleyna-core.json
@@ -1,0 +1,10 @@
+{
+    "name": "dleyna-core",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/intel/dleyna-core.git",
+            "commit": "1c6853f5bc697dc0a8774fd70dbc915c4dbe7c5b"
+        }
+    ]
+}

--- a/dleyna/dleyna-server.json
+++ b/dleyna/dleyna-server.json
@@ -1,0 +1,12 @@
+{
+    "name": "dleyna-server",
+    "config-opts": [ "--with-dleyna-service-name=org.gnome.Totem.dleyna-server" ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/hadess/dleyna-server.git",
+            "commit": "85f647aa41b118bd0961fb9fc92f9a93bb627cb8",
+            "branch": "wip/hadess/dleyna-service-name"
+        }
+    ]
+}

--- a/dleyna/gssdp.json
+++ b/dleyna/gssdp.json
@@ -1,0 +1,12 @@
+{
+    "name": "gssdp",
+    "buildsystem": "meson",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://gitlab.gnome.org/GNOME/gssdp.git",
+            "commit": "454c1d5a8f5e16c49e360696b063732e25ec780b",
+            "tag": "gssdp-1.2.1"
+        }
+    ]
+}

--- a/dleyna/gupnp-av.json
+++ b/dleyna/gupnp-av.json
@@ -1,0 +1,12 @@
+{
+    "name": "gupnp-av",
+    "buildsystem": "meson",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://gitlab.gnome.org/GNOME/gupnp-av.git",
+            "commit": "b4dd4dd0b3f369680367a6c9efb1f9d3077ff074",
+            "tag": "gupnp-av-0.12.11"
+        }
+    ]
+}

--- a/dleyna/gupnp-dlna.json
+++ b/dleyna/gupnp-dlna.json
@@ -1,0 +1,12 @@
+{
+    "name": "gupnp-dlna",
+    "config-opts": [ "--disable-Werror" ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://gitlab.gnome.org/GNOME/gupnp-dlna.git",
+            "commit": "d8c2a40767e47fe8427e019cad5359092a8fa662",
+            "tag": "gupnp-dlna-0.10.5"
+        }
+    ]
+}

--- a/dleyna/gupnp.json
+++ b/dleyna/gupnp.json
@@ -1,0 +1,12 @@
+{
+    "name": "gupnp",
+    "buildsystem": "meson",
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://gitlab.gnome.org/GNOME/gupnp.git",
+            "commit": "b9f76cada1038be75963593ad783d88d9446fce6",
+            "tag": "gupnp-1.2.1"
+        }
+    ]
+}

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -24,8 +24,6 @@
         "--filesystem=home",
         /* Avahi */
         "--system-talk-name=org.freedesktop.Avahi",
-        /* DLNA server */
-        "--talk-name=com.intel.dleyna-server",
         /* Play sounds */
         "--socket=pulseaudio",
         /* Browse user's Videos directory */
@@ -240,6 +238,13 @@
                 }
             ]
         },
+        "dleyna/gssdp.json",
+        "dleyna/gupnp.json",
+        "dleyna/gupnp-av.json",
+        "dleyna/gupnp-dlna.json",
+        "dleyna/dleyna-core.json",
+        "dleyna/dleyna-connector-dbus.json",
+        "dleyna/dleyna-server.json",
         /* XXX Remove the Lua sources we won't use */
         {
             "name": "grilo-plugins",
@@ -258,14 +263,15 @@
                 "-Denable-thetvdb=yes",
                 "-Denable-tmdb=yes",
                 "-Denable-freebox=yes",
-                "-Denable-opensubtitles=yes"
+                "-Denable-opensubtitles=yes",
+                "-Ddleyna-service-name=org.gnome.Totem.dleyna-server"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/grilo-plugins.git",
-                    "commit": "a6330af7d607a6a20364ec2924ad152d16c50cf2",
-                    "tag": "grilo-plugins-0.3.10"
+                    "commit": "c10d291632ab4f70dcba354a16abc5c38a1d4da8",
+                    "branch": "wip/hadess/dleyna-change-bus-name"
                 }
             ],
             "cleanup": [ "/include" ]


### PR DESCRIPTION
TODO:
~~- Change the D-Bus name to something we can own:
  https://github.com/intel/dleyna-server/blob/master/configure.ac#L208~~!
~~- and in the client:
  https://gitlab.gnome.org/GNOME/grilo-plugins/blob/master/src/dleyna/grl-dleyna-source.c#L39~~