### PR TITLE
Update dependencies and housekeeping

### DIFF
--- a/codecs/libdvdnav.json
+++ b/codecs/libdvdnav.json
@@ -4,8 +4,8 @@
         {
             "type": "git",
             "url": "https://code.videolan.org/videolan/libdvdnav.git",
-            "tag": "6.0.0",
-            "commit": "dcb9109e45ccd304ec82a7c7bf46cca63620adf9"
+            "tag": "6.1.0",
+            "commit": "4f48efd43efb2e3372cb494a8893342e1fb507ae"
         },
         {
             "type":"script",

--- a/codecs/libdvdread.json
+++ b/codecs/libdvdread.json
@@ -4,8 +4,8 @@
         {
             "type": "git",
             "url": "https://code.videolan.org/videolan/libdvdread.git",
-            "tag": "6.0.0",
-            "commit": "95fdbe8337d2ff31dcfb68f35f3e4441dc27d92f"
+            "tag": "6.1.0",
+            "commit": "d413571ce39acd404523b6742ba361215f6ada68"
         },
         {
             "type":"script",

--- a/dleyna/gssdp.json
+++ b/dleyna/gssdp.json
@@ -5,8 +5,8 @@
         {
             "type": "git",
             "url": "https://gitlab.gnome.org/GNOME/gssdp.git",
-            "commit": "454c1d5a8f5e16c49e360696b063732e25ec780b",
-            "tag": "gssdp-1.2.1"
+            "commit": "0e87f5aecb661516983767c996d1834909f6901f",
+            "tag": "gssdp-1.2.2"
         }
     ]
 }

--- a/dleyna/gupnp.json
+++ b/dleyna/gupnp.json
@@ -5,8 +5,8 @@
         {
             "type": "git",
             "url": "https://gitlab.gnome.org/GNOME/gupnp.git",
-            "commit": "b9f76cada1038be75963593ad783d88d9446fce6",
-            "tag": "gupnp-1.2.1"
+            "commit": "76f6a78e99f4a4e80f31678ba99e8068131c79ff",
+            "tag": "gupnp-1.2.2"
         }
     ]
 }

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -155,8 +155,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/libgdata.git",
-                    "commit": "5b2e808bcf73bb44e5fc69c04069d7befec70518",
-                    "tag": "0.17.11"
+                    "commit": "6fd85102e7dcf7414000264a263465ba5cb894e4",
+                    "tag": "0.17.12"
                 }
             ]
         },

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -280,8 +280,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gnome-desktop.git",
-                    "commit": "ea41116fa3a4be14526b0b8f495fe028dda9da14",
-                    "tag": "3.33.92.1"
+                    "commit": "8154dd2e0dd3eb84c6802a3836447bd0d9aa7fe6",
+                    "tag": "3.36.1"
                 }
             ]
         },

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -218,11 +218,13 @@
                 "--enable-gobject",
                 "--with-xml=expat",
                 "--disable-libdaemon",
+                "--disable-libevent",
                 "--disable-core-docs",
                 "--disable-manpages",
                 "--disable-mono",
                 "--disable-qt3",
                 "--disable-qt4",
+                "--disable-qt5",
                 "--disable-python",
                 "--disable-gtk",
                 "--disable-gtk3"
@@ -230,8 +232,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://avahi.org/download/avahi-0.7.tar.gz",
-                    "sha256": "57a99b5dfe7fdae794e3d1ee7a62973a368e91e414bd0dfa5d84434de5b14804"
+                    "url": "https://avahi.org/download/avahi-0.8.tar.gz",
+                    "sha256": "060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda"
                 }
             ]
         },

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -190,8 +190,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/tracker.git",
-                    "commit": "f56ccfde3b0a63375d6a4a664928b348c9ea45eb",
-                    "tag": "2.3.0"
+                    "commit": "1fab9a0bf547cc2d12b743b53f0df8423d36e83d",
+                    "tag": "2.3.4"
                 }
             ]
         },

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -78,8 +78,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/libpeas.git",
-                    "commit": "f9962a516ead8ce20531d1b23e1b656caecd9274",
-                    "tag": "libpeas-1.24.0"
+                    "commit": "6b4217e0a5ec451cdbe9380df26d701d8e6bdf88",
+                    "tag": "libpeas-1.26.0"
                 }
             ]
         },

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -6,7 +6,7 @@
     "command": "totem",
     "finish-args": [
         /* X11 + XShm access */
-        "--share=ipc", "--socket=x11",
+        "--share=ipc", "--socket=fallback-x11",
         /* Wayland access */
         "--socket=wayland",
         /* OpenGL access */

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -287,7 +287,6 @@
                 }
             ]
         },
-        "shared-modules/dbus-glib/dbus-glib-0.110.json",
         {
             "name": "python3-dbus-python",
             "buildsystem": "simple",
@@ -297,8 +296,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://pypi.python.org/packages/ad/1b/76adc363212c642cabbf9329457a918308c0b9b5d38ce04d541a67255174/dbus-python-1.2.4.tar.gz",
-                    "sha256": "e2f1d6871f74fba23652e51d10873e54f71adab0525833c19bad9e99b1b2f9cc"
+                    "url": "https://files.pythonhosted.org/packages/62/7e/d4fb56a1695fa65da0c8d3071855fa5408447b913c58c01933c2f81a269a/dbus-python-1.2.16.tar.gz",
+                    "sha256": "11238f1d86c995d8aed2e22f04a1e3779f0d70e587caffeab4857f3c662ed5a4"
                 }
             ]
         },

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -130,8 +130,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gnome-online-accounts.git",
-                    "commit": "41bbfd1f37e64d58115126033c3a0a3aea6e466f",
-                    "tag": "3.30.0"
+                    "commit": "a0931a8253e09e18768270f97b5e093e9df82fa8",
+                    "tag": "3.36.0"
                 }
             ]
         },


### PR DESCRIPTION
Update libdvdnav, libdvdread, gssdp, gupnp, libpeas, gnome-online-accounts,
libgdata, tracker, libmediaart, avahi, gnome-desktop, and dbus-python.

Also, add .gitignore and fix incorrect commit for librest.

The newest version of Avahi 0.8 requires a new dependency, libevent. There is a build flag: `--disable-libevent` that I passed, since I wasn't sure that libevent was needed, since the previous version of Avahi 0.7 without libevent worked fine.

If libevent is necessary, I can remove that flag.

I built and tested the flatpak with a downloaded youtube video, and it seemed to work fine.