### PR TITLE
Update gssdp and gupnp

### DIFF
--- a/dleyna/gssdp.json
+++ b/dleyna/gssdp.json
@@ -5,8 +5,8 @@
         {
             "type": "git",
             "url": "https://gitlab.gnome.org/GNOME/gssdp.git",
-            "commit": "454c1d5a8f5e16c49e360696b063732e25ec780b",
-            "tag": "gssdp-1.2.1"
+            "commit": "a4eb74313a3df17c3ac5b99f3131522e6e8bccf4",
+            "tag": "gssdp-1.2.3"
         }
     ]
 }

--- a/dleyna/gupnp.json
+++ b/dleyna/gupnp.json
@@ -5,8 +5,8 @@
         {
             "type": "git",
             "url": "https://gitlab.gnome.org/GNOME/gupnp.git",
-            "commit": "b9f76cada1038be75963593ad783d88d9446fce6",
-            "tag": "gupnp-1.2.1"
+            "commit": "c7517cdabd8b04c05804d300fd726ff29c90f2ee",
+            "tag": "gupnp-1.2.3"
         }
     ]
 }


### PR DESCRIPTION
The main "feature" of this release is the implementation of the
UDA 2.0 spec addendum from 2020/04/17 which restricts notifications
registered with SUBSCRIBE to the subnet of the server. For this reason,
a new GSSDP version is required to provide the required information.