### PR TITLE
Update runtime to 3.38

### DIFF
--- a/codecs/gst-plugins-bad.json
+++ b/codecs/gst-plugins-bad.json
@@ -4,7 +4,8 @@
     "cleanup": [ "/bin/*webrtc*", "/bin/crossfade", "/bin/tsparser", "/bin/playout" ],
     "config-opts": [
         "-Dopenh264=disabled",
-        "-Dvdpau=disabled"
+        "-Dvdpau=disabled",
+        "-Dvulkan=disabled"
     ],
     "sources": [
         {

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Totem",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "totem",
     "finish-args": [


### PR DESCRIPTION
We'll need to wait for GStreamer 1.18.0 to land in the nightly though