### PR TITLE
Fix remote shares access with gvfs 1.48

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -28,7 +28,7 @@
         "--filesystem=/run/media",
         /* Browse gvfs */
         "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*",
-        "--filesystem=xdg-run/gvfs",
+        "--filesystem=xdg-run/gvfs", "--filesystem=xdg-run/gvfsd",
         /* Migrate DConf settings from the host */
         "--metadata=X-DConf=migrate-path=/org/gnome/Totem/",
         /* screensaver plugin */


### PR DESCRIPTION
The reason for the changes are explained in:
https://gitlab.gnome.org/GNOME/gvfs/-/issues/515#note_919326