### PR TITLE
Add support for QDMC and QDM2 audio codecs

### DIFF
--- a/codecs/ffmpeg.json
+++ b/codecs/ffmpeg.json
@@ -35,7 +35,7 @@
         "--enable-opengl",
         "--enable-sdl2",
         "--enable-decoder=ac3,alac,flac,g723_1,g729,libfdk_aac,libopus,mp2,mp3,m4a,pcm_alaw,pcm_mulaw,pcm_f32le,pcm_s16be,pcm_s24be,pcm_s16le,pcm_s24le,pcm_s32le,pcm_u8,tta,vorbis,wavpack,ape,dca,eac3,mlp,tak,truehd,wmav1,wmav2,wmapro",
-        "--enable-decoder=ass,ffv1,libaom_av1,libdav1d,libopenh264,libvpx_vp8,libvpx_vp9,rawvideo,theora,vp8,vp9,cinepak,flv,hevc,h263,h264,indeo2,indeo3,indeo4,indeo5,mpeg2video,mpeg4,msmpeg4,msmpeg4v1,msmpeg4v2,msmpeg4v3,vp6,vp6a,vp6f,wmv1,wmv2,wmv3,wmv3image",
+        "--enable-decoder=ass,ffv1,libaom_av1,libdav1d,libopenh264,libvpx_vp8,libvpx_vp9,rawvideo,theora,vp8,vp9,cinepak,flv,hevc,h263,h264,indeo2,indeo3,indeo4,indeo5,mpeg2video,mpeg4,msmpeg4,msmpeg4v1,msmpeg4v2,msmpeg4v3,vp6,vp6a,vp6f,wmv1,wmv2,wmv3,wmv3image,qdmc,qdm2",
         "--enable-decoder=gif,png,tiff,webp",
         "--enable-hwaccel=h264_vaapi,h264_vdpau,hevc_vaapi,hevc_vdpau",
         "--enable-parser=aac,ac3,flac,mpegaudio,mpeg4video,opus,vp3,vp8,vorbis,hevc,h264,dca",


### PR DESCRIPTION
The latter is used to decode the audio in the famous Junior Senior music
video.