### PR TITLE
upgrade GNOME platform runtime to version 40

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Totem",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "totem",
     "finish-args": [


### PR DESCRIPTION
The GNOME 3.38 runtime is no longer supported as of August 19, 2021.