### PR TITLE
Update tracker and tracker-miners to 3.2.1

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -196,7 +196,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/tracker.git",
-                    "commit": "90b847c51a8635b784ca39da45b69ed5832f06e7"
+                    "tag": "3.2.1"
                 }
             ]
         },
@@ -219,7 +219,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/tracker-miners.git",
-                    "commit": "191cc5218b53fba85baec1c8c17bb246a74044c0"
+                    "tag": "3.2.1"
                 }
             ]
         },


### PR DESCRIPTION
This should, in particular, include bug fixes in the seccomp sandboxing that are needed to run on newer GLib versions.

Signed-off-by: Ryan Gonzalez <ryan.gonzalez@collabora.com>