### PR TITLE
Fix libav codecs not working anymore

### DIFF
--- a/codecs/gstreamer.json
+++ b/codecs/gstreamer.json
@@ -14,20 +14,25 @@
         "-Ddoc=disabled",
         "-Dgtk_doc=disabled",
         "-Dgpl=enabled",
+        "-Dlibav=enabled",
         "-Dbad=enabled",
         "-Dgst-plugins-bad:openh264=disabled",
         "-Dgst-plugins-bad:vulkan=disabled",
         "-Dugly=enabled",
         "-Dgst-plugins-ugly:mpeg2dec=enabled"
     ],
+    "build-options": {
+        "env": {
+            "PKG_CONFIG_PATH": "/app/lib/codecs/lib/pkgconfig/:/app/lib/pkgconfig"
+        }
+    },
     "cleanup": [ "/bin/*webrtc*", "/bin/crossfade", "/bin/tsparser", "/bin/playout", "/lib/gstreamer-1.0/include/" ],
     "sources": [
         {
             "type": "git",
             "disable-submodules": true,
             "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer.git",
-            "tag": "1.19.3",
-            "commit": "f513c289b0ef48a13aa0b80ba65a0c76c2a77cd2"
+            "commit": "6ea56e7fd39c48e718a10b6e69ec214532789a59"
         },
         {
             "type": "patch",

--- a/codecs/move-gst-plugins.sh
+++ b/codecs/move-gst-plugins.sh
@@ -2,6 +2,7 @@
 
 mkdir -p /app/lib/codecs/lib/gstreamer-1.0
 export GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0
+export LD_LIBRARY_PATH=/app/lib/codecs/lib/:/app/lib/
 
 for i in /app/lib/gstreamer-1.0/*.so; do
   SUITE=`gst-inspect-1.0 $i | grep "Source module" | sed 's,Source module,,' | tr -d [:blank:]`


### PR DESCRIPTION
Tell gstreamer where to get the newer headers and libraries for ffmpeg
rather than relying on the SDK's default paths to include a compatible
version.