### PR TITLE
Remove org.gnome.SettingsDaemon.MediaKeys D-Bus access

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -38,8 +38,6 @@
         "--filesystem=xdg-pictures",
         /* save-file plugin */
         "--talk-name=org.gnome.Nautilus",
-        /* media-player-keys plugin */
-        "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
         /* MPRIS plugin */
         "--own-name=org.mpris.MediaPlayer2.totem",
         /* im-status plugin */


### PR DESCRIPTION
The plugin that used this was removed, as it was obsoleted by the new
MPRIS plugin.