### PR TITLE
Work-around black screen on new Radeon

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -49,7 +49,9 @@
         /* totem-pl-parser extension */
         "--env=PATH=/app/lib/totem-pl-parser/bin/:/app/lib/codecs/bin/:/app/bin:/usr/bin",
         "--env=TOTEM_PL_PARSER_VIDEOSITE_SCRIPT_DIR=/app/lib/totem-pl-parser/bin/",
-        "--env=PYTHONPATH=/app/lib/totem-pl-parser/site-packages"
+        "--env=PYTHONPATH=/app/lib/totem-pl-parser/site-packages",
+        /* Disable glthread, see mesa #7948 */
+        "--env=mesa_glthread=false"
     ],
     "add-extensions": {
         "org.gnome.Totem.Codecs": {


### PR DESCRIPTION
Work-around a GTK+ 3.x GL bug and a Mesa invalid read bug by disabling mesa_glthread support.

See: https://gitlab.gnome.org/GNOME/gtk/-/issues/5517 and https://gitlab.freedesktop.org/mesa/mesa/-/issues/7948

This patch can be reverted when both those issues are fixed: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1547 https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1548