### PR TITLE
Add permission to access DVDs

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -26,6 +26,7 @@
         "--filesystem=xdg-download",
         /* Access DVDs */
         "--filesystem=/run/media",
+        "--filesystem=/media",
         /* Browse gvfs */
         "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-run/gvfs", "--filesystem=xdg-run/gvfsd",


### PR DESCRIPTION
Operating systems such as Debian have DVDs show up in /media. The GNOME Videos Flatpak needs this permission to be able to access DVDs on those operating systems.