### PR TITLE
Update to GNOME 48 runtime

### DIFF
--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Totem",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "totem",
     "finish-args": [

--- a/org.gnome.Totem.json
+++ b/org.gnome.Totem.json
@@ -81,6 +81,18 @@
         "codecs/gstreamer.json",
         "codecs/pipewire.json",
         {
+            "name": "pygobject",
+            "buildsystem": "meson",
+            "config-opts": [ "-Dtests=false" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/pygobject/3.50/pygobject-3.50.0.tar.xz",
+                    "sha256": "8d836e75b5a881d457ee1622cae4a32bcdba28a0ba562193adb3bbb472472212"
+                }
+            ]
+        },
+        {
             "name": "libpeas",
             "buildsystem": "meson",
             "sources": [


### PR DESCRIPTION
We can't merge this, it fails on startup:
```
/usr/lib/python3.12/site-packages/gi/module.py:57: Warning: cannot register existing type 'GIRepository'
  repository = Repository.get_default()
/usr/lib/python3.12/site-packages/gi/module.py:57: Warning: g_once_init_leave_pointer: assertion 'result != 0' failed
  repository = Repository.get_default()
/usr/lib/python3.12/site-packages/gi/module.py:57: Warning: g_object_new_with_properties: assertion 'G_TYPE_IS_OBJECT (object_type)' failed
  repository = Repository.get_default()
```